### PR TITLE
include ability to add dist matrices for #77

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -219,7 +219,7 @@ binary_distance_matrix <- function(facility,
                                         distance_cutoff = distance_cutoff)
     } else {
         # reduce d_proposed_user down to submitted `user_not_covered`:
-        d_proposed_user <- d_proposed_user [, user_not_covered$user_id]
+        d_proposed_user <- d_proposed_user [, user$user_id]
         d_proposed_user [is.na (d_proposed_user)] <-
             max (d_proposed_user, na.rm = TRUE)
         A <- t (d_proposed_user < distance_cutoff)

--- a/man/binary_distance_matrix.Rd
+++ b/man/binary_distance_matrix.Rd
@@ -4,7 +4,8 @@
 \alias{binary_distance_matrix}
 \title{(Internal) Create a binary distance matrix}
 \usage{
-binary_distance_matrix(facility, user, distance_cutoff)
+binary_distance_matrix(facility, user, distance_cutoff,
+  d_proposed_user = NULL)
 }
 \arguments{
 \item{facility}{data.frame of facilities}

--- a/man/find_users_not_covered.Rd
+++ b/man/find_users_not_covered.Rd
@@ -4,7 +4,8 @@
 \alias{find_users_not_covered}
 \title{(Internal) Create a dataframe of the users not covered}
 \usage{
-find_users_not_covered(existing_facility, user, distance_cutoff)
+find_users_not_covered(existing_facility, user, distance_cutoff,
+  d_existing_user = NULL)
 }
 \arguments{
 \item{existing_facility}{data.frame of existing facilities}
@@ -12,6 +13,9 @@ find_users_not_covered(existing_facility, user, distance_cutoff)
 \item{user}{data.frame of existing users}
 
 \item{distance_cutoff}{integer of distance cutoff}
+
+\item{d_existing_user}{Optional distance matrix between existing facilities
+and users.}
 }
 \value{
 data.frame of those users not covered by current facilities

--- a/man/max_coverage.Rd
+++ b/man/max_coverage.Rd
@@ -5,7 +5,8 @@
 \title{Solve the Maximal Covering Location Problem}
 \usage{
 max_coverage(existing_facility, proposed_facility, user, distance_cutoff,
-  n_added, solver = "glpk")
+  n_added, d_existing_user = NULL, d_proposed_user = NULL,
+  solver = "glpk")
 }
 \arguments{
 \item{existing_facility}{data.frame containing the facilities that are
@@ -22,6 +23,14 @@ you are interested in. If a number is less than distance_cutoff, it will be
 1, if it is greater than it, it will be 0.}
 
 \item{n_added}{the maximum number of facilities to add.}
+
+\item{d_existing_user}{Optional distance matrix between existing facilities
+and users. Default distances are direct (geospherical ellipsoidal) distances;
+this allows alternative measures such as street-network distances to be
+submitted (see Examples).}
+
+\item{d_proposed_user}{Option distance matrix between proposed facilities and
+users (see Examples).}
 
 \item{solver}{character "glpk" (default) or "lpSolve". "gurobi" is currently
 in development, see \url{https://github.com/njtierney/maxcovr/issues/25}}
@@ -67,4 +76,26 @@ mc_result$user_affected
 # get the summaries
 mc_result$summary
 
+# Example of street-network distance calculations
+\dontrun{
+library(dodgr)
+net <- dodgr_streetnet_sf ("york england") \%>\%
+    weight_streetnet (wt_profile = "foot")
+
+from <- match_points_to_graph (v, york_selected [, c ("long", "lat")])
+to <- match_points_to_graph (v, york_crime [, c ("long", "lat")])
+d_existing_user <- dodgr_dists (net, from = from, to = to)
+
+from <- match_points_to_graph (v, york_unselected [, c ("long", "lat")])
+d_proposed_user <- dodgr_dists (net, from = from, to = to)
+
+mc_result <- max_coverage(existing_facility = york_selected,
+                          proposed_facility = york_unselected,
+                          user = york_crime,
+                          distance_cutoff = 100,
+                          n_added = 20,
+                          d_existing_user = d_existing_user,
+                          d_proposed_user = d_proposed_user)
+
+}
 }


### PR DESCRIPTION
## Description

Adds 2 more parameters to the `max_coverage` function:

1. `d_existing_user`; and
2. `d_proposed_user`

These are explained in updated `man` entries

## Example

Here's a reprex:

``` r
setwd ("/data/mega/code/forks/maxcovr")
devtools::load_all (".", export_all = TRUE)
#> Loading maxcovr
devtools::load_all ("../../repos/atfutures/dodgr", export_all = FALSE)
#> Loading dodgr
suppressMessages (library (dplyr))
dodgr_cache_off ()
net <- dodgr_streetnet_sc ("york, england") %>%
    weight_streetnet (wt_profile = "foot")
#> Loading required namespace: geodist
v <- dodgr_vertices (net)

existing_facility <- york_selected <- york %>% filter(grade == "I")
proposed_facility <- york_unselected <- york %>% filter(grade != "I")
user <- york_crime 

from <- match_points_to_graph (v, existing_facility [, c ("long", "lat")])
to <- match_points_to_graph (v, user [, c ("long", "lat")])
d_existing <- dodgr_dists (net, from = from, to = to)

from <- match_points_to_graph (v, proposed_facility [, c ("long", "lat")])
d_proposed <- dodgr_dists (net, from = from, to = to)

mc_result <- max_coverage(existing_facility = york_selected,
                          proposed_facility = york_unselected,
                          user = york_crime,
                          distance_cutoff = 100,
                          n_added = 20)
mc_result_dmats <- max_coverage(existing_facility = york_selected,
                                proposed_facility = york_unselected,
                                user = york_crime,
                                distance_cutoff = 100,
                                n_added = 20,
                                d_existing_user = d_existing,
                                d_proposed_user = d_proposed)
summary (mc_result)
#> 
#> ------------------------------------------- 
#> Model Fit: maxcovr fixed location model 
#> ------------------------------------------- 
#> Distance Cutoff: 100m 
#> Facilities: 
#>     Added:       20 
#> Coverage (Previous): 
#>     # Users:     540    (339) 
#>     Proportion:  0.2977 (0.1869) 
#> Distance (m) to Facility (Previous): 
#>     Avg:         886 (1400) 
#>     SD:          986 (1597) 
#> -------------------------------------------
summary (mc_result_dmats)
#> 
#> ------------------------------------------- 
#> Model Fit: maxcovr fixed location model 
#> ------------------------------------------- 
#> Distance Cutoff: 100m 
#> Facilities: 
#>     Added:       20 
#> Coverage (Previous): 
#>     # Users:     490    (339) 
#>     Proportion:  0.2701 (0.1869) 
#> Distance (m) to Facility (Previous): 
#>     Avg:         1092 (1400) 
#>     SD:          1193 (1597) 
#> -------------------------------------------
```

<sup>Created on 2019-11-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

All measures are reduced, simply because 100m of street distance is equivalent to using a lower value of `dist_threshold` in the first model. Alternatively, just put in `dist_threshold = 125` in the model with the distance matrices and you'll get the same number of users covered (540). Distances to facilities nevertheless remain greater, again coz of street distances.

## Tests

... sorry, ain't got no tests, because that requires some kind of distance matrices to be used. We can discuss that later.